### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,22 +6,14 @@
       "outputs": ["{projectRoot}/dist/**"],
       "cache": true
     },
-    "build:client": {
-      "outputs": ["{projectRoot}/dist/**"],
-      "cache": true
-    },
+    "build:client": { "outputs": ["{projectRoot}/dist/**"], "cache": true },
     "build:starter": {
       "dependsOn": ["^build"],
       "outputs": ["{projectRoot}/dist/**"],
       "cache": true
     },
-    "build:website": {
-      "outputs": ["{projectRoot}/build/**"],
-      "cache": true
-    },
-    "lint": {
-      "cache": true
-    }
+    "build:website": { "outputs": ["{projectRoot}/build/**"], "cache": true },
+    "lint": { "cache": true }
   },
   "release": {
     "projects": ["packages/*"],
@@ -33,9 +25,7 @@
       "commitMessage": "chore(release): 🔖 create new tag and release %s"
     },
     "changelog": {
-      "workspaceChangelog": {
-        "createRelease": "github"
-      },
+      "workspaceChangelog": { "createRelease": "github" },
       "projectChangelogs": {
         "renderOptions": {
           "authors": true,
@@ -51,9 +41,7 @@
     {
       "plugin": "@nx/js/typescript",
       "options": {
-        "typecheck": {
-          "targetName": "tsc:typecheck"
-        },
+        "typecheck": { "targetName": "tsc:typecheck" },
         "build": {
           "targetName": "build",
           "configName": "tsconfig.lib.json",
@@ -62,5 +50,6 @@
         }
       }
     }
-  ]
+  ],
+  "nxCloudId": "67fca4d9ebe23f324e74a943"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/67fc92e70afee6727a0dfe6e/workspaces/67fca4d9ebe23f324e74a943

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.